### PR TITLE
Support AWS v6

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0, < 7.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
AWS has released v6. I've skimmed through the update log and it shouldn't break anything. 🤞 

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade